### PR TITLE
Typespecs

### DIFF
--- a/lib/roombex.ex
+++ b/lib/roombex.ex
@@ -2,38 +2,73 @@ defmodule Roombex do
   use Bitwise
   alias Roombex.Sensor
 
+  @spec baud(non_neg_integer()) :: binary()
   def baud(rate), do: << 129, baud_code(rate) >>
+
+  @spec clean() :: binary()
   def clean, do: << 135 >>
+
+  @spec control() :: binary()
   def control, do: << 130 >>
+
+  @spec drive(:straight | :stop | :turn_clockwise | :turn_counter_clockwise) :: binary()
   def drive(:straight), do: << 137, 8, 0, 0, 0 >>
   def drive(:stop), do: << 137 >> <> velocity_bytes(0) <> radius_bytes(0)
   def drive(:turn_clockwise), do: << 137, 255, 255, 255, 255 >>
   def drive(:turn_counter_clockwise), do: << 137, 0, 0, 0, 1 >>
+
+  @spec drive(non_neg_integer(), non_neg_integer()) :: binary()
   def drive(velocity_mm_per_sec, radius_mm) do
     << 137 >> <> velocity_bytes(velocity_mm_per_sec) <> radius_bytes(radius_mm)
   end
+
+  @spec force_seeking_dock() :: binary()
   def force_seeking_dock, do: << 143 >>
+
+  @spec full() :: binary()
   def full, do: << 132 >>
+
+  @spec leds([atom()], float(), float()) :: binary()
   def leds(leds, power_color, power_intensity) do
     << 139, leds_byte(leds, 0), float_to_byte(power_color), float_to_byte(power_intensity) >>
   end
+
+  @spec max() :: binary()
   def max, do: << 136 >>
+
+  @spec motors([atom()]) :: binary()
   def motors(which_motors), do: << 138, motors_byte(which_motors, 0) >>
+
+  @spec play(non_neg_integer()) :: binary()
   def play(number) when number >= 0 and number <= 15 do
     << 141, number >>
   end
+
+  @spec power() :: binary()
   def power, do: << 133 >>
+
+  @spec reset() :: binary()
   def reset, do: << 7 >>
+
+  @spec sensors(non_neg_integer() | atom()) :: binary()
   def sensors(packet_group) when packet_group in 0..255, do: << 142, packet_group >>
   def sensors(packet) when is_atom(packet) do
     packet_id = Sensor.packet_id(packet)
     << 142, packet_id >>
   end
+
+  @spec safe() :: binary()
   def safe, do: << 131 >>
+
+  @spec song(non_neg_integer(), list([...])) :: binary()
   def song(number, notes) when number >= 0 and number <= 15 and length(notes) <= 16 do
     << 140, number, length(notes) >> <> notes_bytes(notes, << >>)
   end
+
+  @spec spot() :: binary()
   def spot, do: << 134 >>
+
+  @spec start() :: binary()
   def start, do: << 128 >>
 
   defp baud_code(300), do: 0

--- a/lib/roombex/dead_reckoner.ex
+++ b/lib/roombex/dead_reckoner.ex
@@ -5,6 +5,7 @@ defmodule Roombex.DeadReckoner do
   @near_upper_bound @max_encoder_count - 5000
   @near_lower_bound 5000
 
+  @spec update(%WhereAmI{}, %{encoder_counts_left: non_neg_integer(), encoder_counts_right: non_neg_integer()}) :: %WhereAmI{}
   def update(%WhereAmI{}=whereami, %{encoder_counts_left: left, encoder_counts_right: right}) do
     left_diff = encoder_diff(whereami.encoder_counts_left, left)
     right_diff = encoder_diff(whereami.encoder_counts_right, right)

--- a/lib/roombex/dj.ex
+++ b/lib/roombex/dj.ex
@@ -7,15 +7,21 @@ defmodule Roombex.DJ do
   @baud_rate 115_200
 
   # Client Interface
+  @spec start_link(keyword(), keyword()) :: GenServer.on_start
   def start_link(dj_opts, process_opts \\ []) do
     GenServer.start_link(__MODULE__, dj_opts, process_opts)
   end
 
+  @spec command(GenServer.server, binary()) :: :ok
   def command(pid \\ __MODULE__, binary), do: GenServer.cast(pid, {:command, binary})
+
+  @spec reset(GenServer.server) :: :ok
   def reset(pid \\ __MODULE__), do: GenServer.cast(pid, :reset)
+
+  @spec sensors(GenServer.server) :: %Roombex.State.Sensors{}
   def sensors(pid \\ __MODULE__), do: GenServer.call(pid, :sensors)
 
-  # GenServer Callbacks
+  @impl GenServer
   def init(opts) do
     # setup connection
     tty = Keyword.fetch!(opts, :tty)
@@ -28,28 +34,33 @@ defmodule Roombex.DJ do
     {:ok, %{serial: serial, roomba: %State{}, report_to: report_to}}
   end
 
+  @impl GenServer
   def handle_call(:sensors, _from, %{roomba: %State{sensors: sensors}}=state) do
     {:reply, sensors, state}
   end
 
+  @impl GenServer
   def handle_cast({:command, binary}, %{serial: device}=state) do
     UART.write(device, binary)
     {:noreply, state}
   end
+  @impl GenServer
   def handle_cast(:reset, %{serial: serial}=state) do
     UART.configure(serial, speed: 19_200) # sometimes the roomba gets set back to the wrong baud rate so we try a reset at the lower baud rate as well
-    UART.write(serial, Roombex.reset)
+    UART.write(serial, Roombex.reset())
     UART.configure(serial, speed: @baud_rate)
-    UART.write(serial, Roombex.reset)
+    UART.write(serial, Roombex.reset())
     send self(), :safe_mode
     :timer.sleep(10_000)
     {:noreply, state}
   end
 
+  @impl GenServer
   def handle_info(:broadcast_sensors, %{roomba: roomba}=state) do
     report_sensor_change(roomba, state)
     {:noreply, state}
   end
+  @impl GenServer
   def handle_info({:nerves_uart, _uart, data}, %{roomba: roomba}=state) do
     old_sensors = roomba.sensors
     roomba = Roombex.State.update(roomba, data)
@@ -58,12 +69,14 @@ defmodule Roombex.DJ do
     end
     {:noreply, %{state | roomba: roomba}}
   end
+  @impl GenServer
   def handle_info({:check_on, sensor_packets}, %{serial: device, roomba: roomba}=state) do
     Enum.each(sensor_packets, &(UART.write(device, Roombex.sensors(&1))))
     # note: rather than handling the case of a faulty UART connection to the roomba, we just ignore old requests that weren't fulfilled
     new_roomba = Map.put(roomba, :expected_sensor_packets, sensor_packets)
     {:noreply, %{state | roomba: new_roomba}}
   end
+  @impl GenServer
   def handle_info(:safe_mode, %{serial: serial}=state) do
     UART.write(serial, Roombex.start)
     :timer.sleep(50)
@@ -71,6 +84,7 @@ defmodule Roombex.DJ do
     :timer.sleep(50)
     {:noreply, state}
   end
+  @impl GenServer
   def handle_info(msg, state) do
     Logger.error "DJ ROOMBEX :: UNEXPECTED MESSAGE :: #{inspect msg}"
     {:noreply, state}

--- a/lib/roombex/sensor.ex
+++ b/lib/roombex/sensor.ex
@@ -56,8 +56,10 @@ defmodule Roombex.Sensor do
     light_bumper_signals: %{id: 106},
   }
 
+  @spec packet_size(atom()) :: non_neg_integer()
   def packet_size(packet) when is_atom(packet), do: Map.fetch!(@packets, packet)[:bytes]
 
+  @spec packet_id(atom()) :: non_neg_integer()
   def packet_id(packet) when is_atom(packet) do
     case Map.get(@packets, packet) do
       %{id: id} -> id
@@ -65,6 +67,7 @@ defmodule Roombex.Sensor do
     end
   end
 
+  @spec parse(atom(), binary()) :: map()
   def parse(:bumps_and_wheeldrops, binary) do
     << _rest::size(4),
        wheel_drop_left::unsigned-size(1),

--- a/lib/roombex/state.ex
+++ b/lib/roombex/state.ex
@@ -101,6 +101,7 @@ defmodule Roombex.State do
             unparsed_binary: <<>>
   import Roombex.Sensor, only: [parse: 2, packet_size: 1]
 
+  @spec update(%Roombex.State{}, binary()) :: %Roombex.State{}
   def update(%Roombex.State{sensors: sensors}=state, binary) do
     binary = state.unparsed_binary <> binary
     {parsed_sensor_values, unparsed_binary, unparsed_packets} = parse_expected_updates(binary, state.expected_sensor_packets)

--- a/lib/roombex/whereami.ex
+++ b/lib/roombex/whereami.ex
@@ -7,10 +7,12 @@ defmodule Roombex.WhereAmI do
             encoder_counts_left: 0,
             encoder_counts_right: 0
 
+  @spec init() :: %__MODULE__{}
   def init() do
     %__MODULE__{}
   end
 
+  @spec init(map()) :: %__MODULE__{}
   def init(%{encoder_counts_left: left, encoder_counts_right: right}) do
     %__MODULE__{encoder_counts_left: left, encoder_counts_right: right}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -17,6 +17,7 @@ defmodule Roombex.Mixfile do
         main: "readme",
         extras: ["README.md"],
       ],
+      dialyzer: [plt_add_deps: :apps_direct, plt_add_apps: [:nerves_uart]],
     ]
   end
 
@@ -28,7 +29,8 @@ defmodule Roombex.Mixfile do
   defp deps do
     [
       {:nerves_uart, "~> 0.1.2", optional: true},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "erlang-serial": {:git, "https://github.com/knewter/erlang-serial.git", "61821783259551090af7a8561891a345c0547af2", []},
   "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
Adds typespecs and dialyxir to the project. This will make so that we can run `mix dialyzer` have [dialyzer](http://erlang.org/doc/man/dialyzer.html) do success type checking on our project. This also means that other people who are using dialyzer in their project will have type hints about what our public functions expect and return.

I also added some `@impl` tags [which are used as of elixir 1.5](https://elixir-lang.org/blog/2017/07/25/elixir-v1-5-0-released/#impl) which will add some compile-time checks to make sure we are implementing the genserver callbacks correctly.